### PR TITLE
Adicionado suporte ao reordenamento de camadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ De forma a evitar eventuais problemas de compatibilidade entre as duas versões 
 
 [Demonstração do sistema](https://webgente.genteufv.com.br/)
 
+Veja [aqui em nosso Roadmap](https://trello.com/b/m0kp6VkF) o que está por vir nas próximas atualizações do WebGENTE e nos acompanhe!
+
 A equipe de desenvolvimento do WebGENTE é composta por:
 
 ## Coordenação

--- a/public/css/administracao.css
+++ b/public/css/administracao.css
@@ -222,3 +222,46 @@ margin: 12px 15px;
     font-size: 0.8em;
     margin: 2px;
 }
+
+/* CSS da área de reordenamento de camadas */
+
+.sortable {
+    cursor: move; /* fallback if grab cursor is unsupported */
+    cursor: grab;
+    cursor: -moz-grab;
+    cursor: -webkit-grab;
+}
+
+.sortable:active {
+    cursor: grabbing;
+    cursor: -moz-grabbing;
+    cursor: -webkit-grabbing;
+}
+
+.layers-list {
+    list-style-type: none
+}
+
+.list-title {
+    width: 20%;
+}
+
+.layer-list-item {
+    width: 30vw;
+}
+
+.groups-list {
+    list-style-type: none
+}
+
+.group-list-item {
+
+}
+
+.draggable-group {
+
+}
+
+.draggable-layer {
+
+}

--- a/views/layers.ejs
+++ b/views/layers.ejs
@@ -47,8 +47,14 @@
 
   var layerId = []
 
+  /* Adição dos botões de remover e adicionar camadas */
   $( document ).ready(function() {
     $('.fixed-table-toolbar').prepend('<button class="btn btn-dark layer-toolbar" id="remove-layers"  style="margin-right:5px;" data-toggle="modal" data-target="#modalAllLayers"onClick="ModalAllLayers(null, null)">Remover Camadas</button> <a class="btn btn-dark layer-toolbar" id="addNewLayer"  style="margin-left:5px;" href="/layers/add"">Nova Camada</a>')
+  });
+
+  /* Adição do botão de reordenar camadas */
+  $( document ).ready(function() {
+    $('.fixed-table-toolbar').append('<a class="btn btn-dark layer-toolbar" id="reorderLayers"  style="margin-left:5px;" href="/layers/reorder"">Reordernar camadas</a>')
   });
 
   /* Aplicação de raio e margem nos botões de ação*/

--- a/views/reorder.ejs
+++ b/views/reorder.ejs
@@ -1,0 +1,130 @@
+<%- include('partials/admin/header.ejs') %>
+
+<link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+
+<div class="container shadow-sm container-form-webgente-admin" >
+    <div class="container">
+        <h3>Reordene a exibição das camadas no WebGENTE</h3>
+        <p>A ordem das camadas define sua sobreposição no mapa, sendo assim, 
+            uma camada mais ao topo na lista será sobreposta por uma camada
+            abaixo na lista ao ser chamada. Você pode reordenar os grupos e as camadas
+            dentro destes. Para alterar o grupo de uma camada utilize a interface
+            de edição da camada.</p>
+        <hr>
+        <div class="col" >
+            <h6>Ordem de chamada das camadas base</h6>
+            <ul id='basemap-list-container' class='list-group groups-list'></ul>
+            <h6>Ordem de chamada das camadas e grupos de sobreposição</h6>
+            <ul id='list-container' class='list-group sortable groups-list'></ul>
+        </div>
+    </div>
+    <hr> 
+    <button id="save-button" class="btn btn-dark" onClick="beforeSubmit()">Salvar</button> &nbsp;<img src="/img/ajax-loader.gif" alt="Carregando" id='loading-img' style="height: 20px; width: 20px; visibility: hidden;">
+</div>
+<script>
+
+    /* Funções auxiliares para a criação/manutenção da lista */
+    function onlyUnique(value, index, self) {
+        return self.indexOf(value) === index;
+    }
+
+    function onlyOverlays(value) {
+        return value.type == 2
+    }
+
+    function onlyNotOverlays(value) {
+        return value.type == 2
+    }
+
+    /* Populando a lista de camadas */
+    $.get({
+        url: '/listlayers',
+        success: (layers) => {
+
+            console.log(layers)
+
+            basemaps = layers.filter(onlyNotOverlays)
+
+            /* Construindo os grupos */
+            var groups = layers.filter(onlyOverlays).map(e => e.group).filter(onlyUnique)
+            
+            /* Adicionando grupo de basemaps no topo da lista sem possibilitar reordenamento do grupo */
+            $('#basemap-list-container').append('<li class="list-group-item draggable-layer ui-state-default group-list-item"><div class="row draggable-group" id="basemaps"><h6 class="list-title">Mapas Base</h6><br><ul id="basemap-list" class="sortable layers-list"></ul></div><li><hr>')
+
+            /* Adicionando os demais grupos */
+            for (i = 0; i < groups.length; i++) {
+                $('#list-container').append('<li class="list-group-item ui-state-default group-list-item"><div class="row draggable-group" id="'+groups[i].split(" ").join('')+'-container"><h6 class="list-title"><span class="ui-icon ui-icon-arrowthick-2-n-s"></span> '+groups[i]+'</h6><br><ul id="'+groups[i].split(" ").join('')+'-list" class="sortable layers-list"></ul></div><li>')
+            }
+
+            /* Atribuindo cada layer em seu respectivo grupo */
+            for (i = 0; i < layers.length; i++) {
+                if (layers[i].type == 1 || layers[i].type == 3) {
+                    $('#basemap-list').append('<li class="list-group-item ui-state-default layer-list-item" data-previous-id="'+layers[i].id+'"><span class="ui-icon ui-icon-arrowthick-2-n-s"></span>'+layers[i].layerName+'</li>')
+                } else {
+                    $('#'+layers[i].group.split(" ").join('')+'-list').append('<li class="list-group-item ui-state-default layer-list-item" data-previous-id="'+layers[i].id+'"><span class="ui-icon ui-icon-arrowthick-2-n-s"></span>'+layers[i].layerName+'</li>')
+                }          
+            }
+
+            /* Ativando comportamento de reordenamento da lista */
+            $( function() {
+                $( ".sortable" ).sortable();
+                $( ".sortable" ).disableSelection();
+            } );
+        }
+    })
+
+    function beforeSubmit() {
+
+        $('#save-button').prop('disabled', true);
+        $('#loading-img').css('visibility', 'visible');
+
+        /* Coletando a nova ordem de camadas dada pelo reordenamento manual */
+        var sortedLayers = $('.layer-list-item').map(function(){
+            return $.trim($(this).text());
+        }).get();
+
+        /* Coletando a ordem de IDs anteriores */
+        var sortedLayersPreviousIDs = $('.layer-list-item').map(function(){
+            return $.trim($(this).data('previous-id'));
+        }).get();
+
+        /* Criando objeto para reordenamento com incremento de milhar */
+        var reordering = []
+        for (i = 0; i < sortedLayers.length; i ++) {
+            reordering.push([i,Number.parseInt(sortedLayersPreviousIDs[i])])
+        }
+
+        console.log(reordering)
+
+        $.post({
+            url: '/layers/reorder',
+            data: {reordering: JSON.stringify(reordering)},  
+            success: () => {
+                window.open('/layers','_self')
+            },
+            error: function(x,e) {
+
+                $('#save-button').prop('disabled', false);
+                $('#loading-img').css('visibility', 'hidden');
+
+                if (x.status==0) {
+                    alert('You are offline!!\n Please Check Your Network.');
+                } else if(x.status==404) {
+                    alert('Requested URL not found.');
+                } else if(x.status==500) {
+                    alert('Internel Server Error.');
+                } else if(e=='parsererror') {
+                    alert('Error.\nParsing JSON Request failed.');
+                } else if(e=='timeout'){
+                    alert('Request Time out.');
+                } else {
+                    alert('Unknow Error.\n'+x.responseText);
+                }
+            }
+        })
+    }
+
+</script>
+
+<%- include('partials/admin/footer.ejs') %>


### PR DESCRIPTION
- Adicionado botão na área de administração de camadas para realizar o reordenamento desta

- Camadas são sobrepostas conforme sua ordem de chamada, sendo assim, camadas mais abaixo do menu de camadas sobrepõem aquelas mais acima. Isto estava criando alguns efeitos indesejados à depender da ordem de declaração das camadas na interface: uma camada de quadra declarada após uma camada de lotes impediria a visualização de ambas camadas simultaneamente devido à sobreposição da primeira à segunda.

- A interface de reordenamento permite reordenar tanto os grupos quanto as camadas dentro dos grupos

- O reordenamento é feito via uma requisição POST à rota /layers/reorder, no corpo da requisição são enviados os id's da ordem antiga das camadas e a nova ordem, realiza-se o reordenamento alterando os id's, e, dessa forma, alterando a forma como o Sequelize serve as camadas por todas as interfaces (ordenadas pelo novo id)

- A criação da lista é realizada dinamicamente e o draggable é dado pelo jQuery-UI, colocado via CDN unicamente na página reorder.ejs

- Para todos os elementos foram atribuidas classes e linkadas em administracao.css, ainda que nao tenham personalizações. O CSS principal neste commit é todo do Bootstrap